### PR TITLE
🔒 Fix DOM XSS in ErrorMessageComponent

### DIFF
--- a/src/app/Popup/error-message/error-message.component.css
+++ b/src/app/Popup/error-message/error-message.component.css
@@ -1,0 +1,3 @@
+.error-text {
+  white-space: pre-wrap;
+}

--- a/src/app/Popup/error-message/error-message.component.html
+++ b/src/app/Popup/error-message/error-message.component.html
@@ -1,8 +1,7 @@
 <h2 mat-dialog-title>Statistic</h2>
 <mat-dialog-content>
-  <div [innerHTML]="formattedMessage"></div>
+  <div class="error-text">{{ data.message }}</div>
 </mat-dialog-content>
 <mat-dialog-actions>
-<button mat-button (click)="errorPopup()">OK</button>
+  <button mat-button (click)="errorPopup()">OK</button>
 </mat-dialog-actions>
-

--- a/src/app/Popup/error-message/error-message.component.spec.ts
+++ b/src/app/Popup/error-message/error-message.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { ErrorMessageComponent } from './error-message.component';
+
+describe('ErrorMessageComponent', () => {
+  let component: ErrorMessageComponent;
+  let fixture: ComponentFixture<ErrorMessageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ErrorMessageComponent],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: { message: 'Test\nMessage' } },
+        { provide: MatDialogRef, useValue: {} }
+      ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ErrorMessageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/Popup/error-message/error-message.component.ts
+++ b/src/app/Popup/error-message/error-message.component.ts
@@ -7,13 +7,11 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
   styleUrls: ['./error-message.component.css'],
 })
 export class ErrorMessageComponent {
-  formattedMessage: string;
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: { message: string },
     public dialogRef: MatDialogRef<ErrorMessageComponent>
-  ) {
-    this.formattedMessage = data.message.replace(/\n/g, '<br>');
-  }
+  ) {}
+
   errorPopup(): void {
     window.location.href = '/home';
   }


### PR DESCRIPTION
🎯 **What:** Fixed a potential DOM XSS vulnerability in `ErrorMessageComponent`.
⚠️ **Risk:** The previous implementation manually replaced newline characters with `<br>` tags and bound the result to `[innerHTML]`. If the source message contained malicious scripts, they could be executed because `innerHTML` binds raw HTML. While Angular's sanitizer provides some protection, this pattern is risky and unnecessary for simple text formatting.
🛡️ **Solution:**
1.  **Removed `innerHTML` binding:** Switched to standard Angular interpolation `{{ data.message }}`. This automatically escapes all content, treating it as safe text.
2.  **CSS for Formatting:** Added `.error-text { white-space: pre-wrap; }` to the CSS. This tells the browser to respect newline characters (`\n`) and wrap text, achieving the same visual result as `<br>` tags without the security risk.
3.  **Code Cleanup:** Removed the manual string replacement logic from the TypeScript file.
4.  **Testing:** Added a basic unit test `error-message.component.spec.ts` to verify component creation.

---
*PR created automatically by Jules for task [14376336912464032915](https://jules.google.com/task/14376336912464032915) started by @Baerspektivo*