### PR TITLE
🔒 Fix DOM XSS in Statistik and ErrorMessage Components

### DIFF
--- a/src/app/Popup/error-message/error-message.component.css
+++ b/src/app/Popup/error-message/error-message.component.css
@@ -1,0 +1,3 @@
+.message-content {
+  white-space: pre-wrap;
+}

--- a/src/app/Popup/error-message/error-message.component.html
+++ b/src/app/Popup/error-message/error-message.component.html
@@ -1,8 +1,7 @@
 <h2 mat-dialog-title>Statistic</h2>
 <mat-dialog-content>
-  <div [innerHTML]="formattedMessage"></div>
+  <div class="message-content">{{ data.message }}</div>
 </mat-dialog-content>
 <mat-dialog-actions>
 <button mat-button (click)="errorPopup()">OK</button>
 </mat-dialog-actions>
-

--- a/src/app/Popup/error-message/error-message.component.ts
+++ b/src/app/Popup/error-message/error-message.component.ts
@@ -7,13 +7,11 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
   styleUrls: ['./error-message.component.css'],
 })
 export class ErrorMessageComponent {
-  formattedMessage: string;
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: { message: string },
     public dialogRef: MatDialogRef<ErrorMessageComponent>
-  ) {
-    this.formattedMessage = data.message.replace(/\n/g, '<br>');
-  }
+  ) {}
+
   errorPopup(): void {
     window.location.href = '/home';
   }

--- a/src/app/Popup/statistik/statistik.component.css
+++ b/src/app/Popup/statistik/statistik.component.css
@@ -1,0 +1,3 @@
+.message-content {
+  white-space: pre-wrap;
+}

--- a/src/app/Popup/statistik/statistik.component.html
+++ b/src/app/Popup/statistik/statistik.component.html
@@ -1,8 +1,7 @@
 <h2 mat-dialog-title>Statistic</h2>
 <mat-dialog-content>
-  <div [innerHTML]="formattedMessage"></div>
+  <div class="message-content">{{ data.message }}</div>
 </mat-dialog-content>
 <mat-dialog-actions>
 <button mat-button (click)="openStatisticPopup()">OK</button>
 </mat-dialog-actions>
-

--- a/src/app/Popup/statistik/statistik.component.ts
+++ b/src/app/Popup/statistik/statistik.component.ts
@@ -7,13 +7,11 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
   styleUrls: ['./statistik.component.css'],
 })
 export class StatistikComponent {
-  formattedMessage: string;
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: { message: string },
     public dialogRef: MatDialogRef<StatistikComponent>
-  ) {
-    this.formattedMessage = data.message.replace(/\n/g, '<br>');
-  }
+  ) {}
+
   openStatisticPopup(): void {
     window.location.href = '/home';
   }


### PR DESCRIPTION
Fixed DOM XSS in StatistikComponent and ErrorMessageComponent by removing innerHTML binding and using secure interpolation.

---
*PR created automatically by Jules for task [3762491112971354501](https://jules.google.com/task/3762491112971354501) started by @Baerspektivo*