### PR TITLE
🔒 Fix DOM XSS vulnerability in PopUpComponent

### DIFF
--- a/src/app/Popup/pop-up/pop-up.component.css
+++ b/src/app/Popup/pop-up/pop-up.component.css
@@ -17,3 +17,7 @@
   box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2);
   text-align: center;
 }
+
+.message-content {
+  white-space: pre-wrap;
+}

--- a/src/app/Popup/pop-up/pop-up.component.html
+++ b/src/app/Popup/pop-up/pop-up.component.html
@@ -1,7 +1,7 @@
 
  <h2 mat-dialog-title>Warning</h2>
 <mat-dialog-content>
-  <div [innerHTML]="formattedMessage"></div>
+  <div class="message-content">{{ data.message }}</div>
 </mat-dialog-content>
 <mat-dialog-actions>
   <button mat-button (click)="closePopUp()">OK</button>

--- a/src/app/Popup/pop-up/pop-up.component.ts
+++ b/src/app/Popup/pop-up/pop-up.component.ts
@@ -7,13 +7,11 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
   styleUrls: ['./pop-up.component.css'],
 })
 export class PopUpComponent {
-  formattedMessage: string;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: { message: string },
     public dialogRef: MatDialogRef<PopUpComponent>
   ) {
-    this.formattedMessage = data.message.replace(/\n/g, '<br>');
   }
   closePopUp(): void {
     this.dialogRef.close();


### PR DESCRIPTION
This PR addresses a potential DOM XSS vulnerability in `PopUpComponent` where user-controlled messages were being rendered using `[innerHTML]` after a simple newline replacement.

**Risk:**
An attacker could potentially inject malicious HTML or JavaScript via the `message` property if it originated from an untrusted source, leading to Cross-Site Scripting (XSS).

**Solution:**
- Removed manual newline-to-`<br>` replacement in the component logic.
- Replaced the vulnerable `[innerHTML]` binding with safe Angular interpolation `{{ data.message }}`.
- Added the `.message-content { white-space: pre-wrap; }` CSS rule to preserve the original newline formatting visually without risking script execution.

This change ensures that all content is treated as text by Angular's default sanitization, eliminating the XSS vector while maintaining the correct visual display of messages.

---
*PR created automatically by Jules for task [8730097595331200323](https://jules.google.com/task/8730097595331200323) started by @Baerspektivo*